### PR TITLE
remover ternario do titulo das colunas

### DIFF
--- a/src/components/Coluna/Coluna.js
+++ b/src/components/Coluna/Coluna.js
@@ -7,7 +7,7 @@ const Coluna = (props) => {
             <div className={`border-top border-top__${color}`}></div>
             <div className='column-title'>
                 <img alt='icone' src={require(`./img/icon-${img}.png`)} />
-                <h2 className={`${nameColumn === 'Done' ? 'column-title__black' : 'column-title__white'}`}>{nameColumn}</h2>
+                <h2>{nameColumn}</h2>
             </div>
             <div className='column-cards'>
                 {children.map(e => e)}


### PR DESCRIPTION
Remoção de um if ternário que adicionava classes que selecionavam as cores do texto.